### PR TITLE
v2.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ O plug-in anexa o boleto, mostra código de barras e linha digitável nos e-mail
 
 Fácil, prático e rápido!
 
-* **Versão mais Recente:** 2.1.4
+* **Versão mais Recente:** 2.1.5
 * **Requer WooCommerce** versão mínima 3.5
 * **Requer Wordpress** preferencialmente atualizado
 * **Requisitos:** PHP >= 5.6.0, Suporte a JSON e permissões de escrita na pasta uploads.
@@ -43,6 +43,16 @@ Para dúvidas comerciais e/ou sobre o funcionamento do serviço, visite a nossa 
 
 * Envio de e-mails de lembrete automatizados pelo Woocommerce, com comunicação da loja para maior conversão
 * Implementação de funcionalidade de boleto parcelado
+
+## 2.1.5 - 2021/04/14
+
+* Melhoria: Mais informações nos logs
+* Melhoria: Lógica de re-emissão aprimorada
+* Bugfix: Transações (PIX e Boleto) sendo geradas duas vezes na criação do pedido
+* Bugfix: Cancelamento de PIX e boleto não mudam mais o status do pedido, mesmo que o método de pagamento tenha sido mudado
+* Bugfix: E-mails de nova data de vencimento não eram enviados (dependendo da versão do Woocommerce)
+* Bugfix: Controle mais estrito do estoque
+* Bugfix: Instruções de pagamento eram mostrados várias vezes, dependendo das condições
 
 ## 2.1.4 - 2021/02/14
 

--- a/includes/class-wc-paghiper-admin.php
+++ b/includes/class-wc-paghiper-admin.php
@@ -226,8 +226,10 @@ class WC_Paghiper_Admin {
 		}
 
 		$gateway_name = $order->get_payment_method();
+		$billing_email = (property_exists(get_billing_email, $order)) ? $order->get_billing_email : $order->get_billing_email();
 
-		$subject = sprintf( __( 'O boleto do seu pedido foi atualizado (%s)', 'woo_paghiper' ), $order->get_order_number() );
+		if(!$billing_email)
+			return;
 
 		$subject = sprintf( __( 'O %s do seu pedido foi atualizado (%s)', 'woo_paghiper' ), (($gateway_name !== 'paghiper_pix') ? 'boleto' : 'PIX'), $order->get_order_number() );
 

--- a/includes/class-wc-paghiper-admin.php
+++ b/includes/class-wc-paghiper-admin.php
@@ -251,7 +251,7 @@ class WC_Paghiper_Admin {
 		$message = $mailer->wrap_message( sprintf(__( 'Nova data de vencimento para o seu %s', 'woo_paghiper' ), ((($gateway_name !== 'paghiper_pix') ? 'boleto' : 'PIX'))), $main_message );
 
 		// Send email.
-		$mailer->send( $order->get_billing_email, $subject, $message, $headers, '' );
+		$mailer->send( $billing_email, $subject, $message, $headers, '' );
 	}
 }
 

--- a/includes/class-wc-paghiper-base-gateway.php
+++ b/includes/class-wc-paghiper-base-gateway.php
@@ -530,14 +530,21 @@ class WC_Paghiper_Base_Gateway {
 
 		$order 		= (is_numeric($order)) ? wc_get_order($order) : $order;
 		$order_id 	= $order->get_id();
+		$order_payment_method = $order->get_payment_method();
+		$order_status = (strpos($order->get_status(), 'wc-') === false) ? 'wc-'.$order->get_status() : $order->get_status();
 
 		// Locks this action for misfiring when order is placed with other gateways
-		if(!in_array($order->get_payment_method(), ['paghiper', 'paghiper_billet', 'paghiper_pix'])) {
+		if(!in_array($order_payment_method, ['paghiper', 'paghiper_billet', 'paghiper_pix'])) {
 			return;
 		}
 
 		// Fallback for old billet transactions
 		if($order->get_payment_method() !== $this->gateway->id && $order->get_payment_method() !== 'paghiper') {
+			return;
+		}
+
+		// Breaks execution if order is not in the right state
+		if(apply_filters('woo_paghiper_pending_status', $this->gateway_settings['set_status_when_waiting'], $order) !== $order_status) {
 			return;
 		}
 

--- a/includes/class-wc-paghiper-base-gateway.php
+++ b/includes/class-wc-paghiper-base-gateway.php
@@ -552,7 +552,7 @@ class WC_Paghiper_Base_Gateway {
 		}
 
 		// Breaks execution if order is not in the right state
-		if(apply_filters('woo_paghiper_pending_status', $this->gateway_settings['set_status_when_waiting'], $order) !== $order_status) {
+		if(apply_filters('woo_paghiper_pending_status', $this->set_status_when_waiting, $order) !== $order_status) {
 			return;
 		}
 

--- a/includes/class-wc-paghiper-base-gateway.php
+++ b/includes/class-wc-paghiper-base-gateway.php
@@ -577,7 +577,9 @@ class WC_Paghiper_Base_Gateway {
 	function email_instructions( $order, $sent_to_admin ) {
 
 		$order_status = (strpos($order->get_status(), 'wc-') === false) ? 'wc-'.$order->get_status() : $order->get_status();
-		if ( $sent_to_admin || apply_filters('woo_paghiper_pending_status', $this->set_status_when_waiting, $order) !== $order_status || strpos($order->get_payment_method(), 'paghiper') === false || ($order->get_payment_method() == 'paghiper_pix' && $order->get_payment_method() !== $this->gateway->id)) {
+		$order_payment_method = $order->get_payment_method();
+
+		if ( $sent_to_admin || apply_filters('woo_paghiper_pending_status', $this->set_status_when_waiting, $order) !== $order_status || strpos($order_payment_method, 'paghiper') === false || $order_payment_method !== $this->gateway->id) {
 			return;
 		}
 
@@ -591,7 +593,7 @@ class WC_Paghiper_Base_Gateway {
 
 		$message = $paghiperTransaction->printBarCode();
 
-		if($order->get_payment_method() !== 'paghiper_pix') {
+		if($order_payment_method !== 'paghiper_pix') {
 
 			$message .= sprintf( __( '%sAtenção!%s Você NÃO vai receber o boleto pelos Correios.', 'woo-boleto-paghiper' ), '<strong>', '</strong>' ) . '<br />';
 			$message .= __( 'Se preferir, você pode imprimir e pagar o boleto em qualquer agência bancária ou lotérica.', 'woo-boleto-paghiper' ) . '<br />';

--- a/includes/class-wc-paghiper-base-gateway.php
+++ b/includes/class-wc-paghiper-base-gateway.php
@@ -228,7 +228,7 @@ class WC_Paghiper_Base_Gateway {
 		);
 
 		if($this->gateway->id == 'paghiper_pix') {
-			unset($first['open_after_day_due']);
+			unset($first['skip_non_workdays'], $first['open_after_day_due']);
 		}
 
 		return array_merge( $first, $last );

--- a/includes/class-wc-paghiper-base-gateway.php
+++ b/includes/class-wc-paghiper-base-gateway.php
@@ -463,6 +463,7 @@ class WC_Paghiper_Base_Gateway {
 		$transaction = $paghiperTransaction->create_transaction();
 
 		if($transaction) {
+
 			// Mark as on-hold (we're awaiting the ticket).
 			$waiting_status = (!empty($this->set_status_when_waiting)) ? $this->set_status_when_waiting : 'on-hold';
 			$order->update_status( $waiting_status, __( 'PagHiper: '. ($this->gateway->id == 'paghiper_pix') ? 'PIX' : 'Boleto' .' gerado e enviado por e-mail.', 'woo-boleto-paghiper' ) );
@@ -476,7 +477,14 @@ class WC_Paghiper_Base_Gateway {
 			}
 
 			if ( $this->log ) {
-				wc_paghiper_add_log( $this->log, sprintf( 'Pedido %s: Não foi possível gerar o '. ($this->gateway->id == 'paghiper_pix') ? 'PIX' : 'boleto' .'. Detalhes: %s', var_export($transaction, true) ) );
+				wc_paghiper_add_log( 
+					$this->log, 
+					sprintf( 'Pedido #%s: Não foi possível gerar o %s. Detalhes: %s', 
+						$order_id, 
+						(($this->gateway->id == 'paghiper_pix') ? 'PIX' : 'boleto'), 
+						var_export($transaction, true) 
+					) 
+				);
 			}
 			
 			wc_add_notice( 'Não foi possível gerar o seu '. (($this->gateway->id == 'paghiper_pix') ? 'PIX' : 'boleto'), 'error' );

--- a/includes/class-wc-paghiper-base-gateway.php
+++ b/includes/class-wc-paghiper-base-gateway.php
@@ -365,7 +365,6 @@ class WC_Paghiper_Base_Gateway {
 	
 					$maybe_valid_taxid = preg_replace('/\D/', '', sanitize_text_field($_POST[$taxid_post_key]));
 					
-	
 					// TODO: Check if item key exists in order meta too
 					if($validateAPI->validate_taxid($maybe_valid_taxid)) {
 						$valid_keys[] = $taxid_post_key;
@@ -401,7 +400,12 @@ class WC_Paghiper_Base_Gateway {
 			} else {
 				if(!empty($not_empty_keys)) {
 					wc_clear_notices();
-					wc_add_notice(  '<strong>Número de CPF</strong> inválido!', 'error' );
+
+					if(strlen($maybe_valid_taxid) > 11) {
+						wc_add_notice(  '<strong>Número de CNPJ</strong> inválido!', 'error' );
+					} else {
+						wc_add_notice(  '<strong>Número de CPF</strong> inválido!', 'error' );
+					}
 				}
 			}
 		}

--- a/includes/class-wc-paghiper-base-gateway.php
+++ b/includes/class-wc-paghiper-base-gateway.php
@@ -475,11 +475,11 @@ class WC_Paghiper_Base_Gateway {
 				$order->add_order_note( sprintf( __( 'Atenção! Total da transação excede R$ 9.000. Caso ainda não o tenha feito, entre em contato com nossa equipe comercial para liberação através do e-mail <a href="comercial@paghiper.com" target="_blank">comercial@paghiper.com</a>', 'woo_paghiper' ) ) );
 			}
 
-			if ( 'yes' === $this->debug ) {
+			if ( $this->log ) {
 				wc_paghiper_add_log( $this->log, sprintf( 'Pedido %s: Não foi possível gerar o '. ($this->gateway->id == 'paghiper_pix') ? 'PIX' : 'boleto' .'. Detalhes: %s', var_export($transaction, true) ) );
 			}
 			
-			wc_add_notice( 'Não foi possível gerar o seu '. ($this->gateway->id == 'paghiper_pix') ? 'PIX' : 'boleto', 'error' );
+			wc_add_notice( 'Não foi possível gerar o seu '. (($this->gateway->id == 'paghiper_pix') ? 'PIX' : 'boleto'), 'error' );
 			return;
 
 		}

--- a/includes/class-wc-paghiper-transaction.php
+++ b/includes/class-wc-paghiper-transaction.php
@@ -26,6 +26,7 @@ class WC_PagHiper_Transaction {
 
 		// Pegamos o pedido completo
 		$this->order = new WC_Order( $order_id );
+		$this->order_status = (strpos($this->order->get_status(), 'wc-') === false) ? 'wc-'.$this->order->get_status() : $this->order->get_status();
 
 		// Pega a configuração atual do plug-in.
 		$this->gateway_id = $this->order->get_payment_method();
@@ -371,7 +372,7 @@ class WC_PagHiper_Transaction {
 
 	public function create_transaction() {
 
-		if($this->has_issued_valid_transaction()) {
+		if($this->has_issued_valid_transaction() || apply_filters('woo_paghiper_pending_status', $this->set_status_when_waiting, $this->order) !== $this->order_status) {
 			return false;
 		}
 
@@ -539,6 +540,10 @@ class WC_PagHiper_Transaction {
 	public function print_transaction_barcode($print = FALSE) {
 
 		$digitable_line = $this->_get_digitable_line();
+
+		if(!$digitable_line)
+			return false;
+
 		$due_date = (DateTime::createFromFormat('Y-m-d', $this->order_data['order_transaction_due_date']))->format('d/m/Y');
 
 		$html = '<div class="woo_paghiper_digitable_line" style="margin-bottom: 40px;">';

--- a/includes/class-wc-paghiper-transaction.php
+++ b/includes/class-wc-paghiper-transaction.php
@@ -592,12 +592,12 @@ class WC_PagHiper_Transaction {
 					$html .= '</div>';
 					$html .= sprintf('<div class="paghiper-pix-code" onclick="copyPaghiperEmv()"><p>Pagar com PIX copia e cola - <button>Clique para copiar</button></p><div class="textarea-container"><textarea readonly rows="3">%s</textarea></div></div>', $digitable_line);
 				} else {
-					$html .= ($barcode_url) ? "<img src='{$barcode_url}' title='Código de barras do PIX deste pedido.' style='max-width: 100%; margin: 0 auto;'>" : '';
+					$html .= ($barcode_url) ? "<p style='text-align: center;'><img src='{$barcode_url}' title='Código de barras do PIX deste pedido.' style='max-width: 100%; margin: 0 auto;'></p>" : '';
 					$html .= "<p style='width: 100%; text-align: center;'>Data de vencimento: <strong>{$due_date}</strong></p>";
 					$html .= "<p style='width: 100%; text-align: center;'>Seu código PIX: {$digitable_line}</p>";
 				}
 	
-				$html .= "<p style='width: 100%; text-align: center; margin-top: 20px;'>Após o pagamento, podemos levar alguns segundos para confirmar o seu pagamento.<br>Você será avisado assim que isso ocorrer!</p>";
+				$html .= "<p style='width: 100%; text-align: center; margin-top: 20px;'>Após o pagamento, podemos levar alguns segundos para confirmar o seu pagamento.<br>Você será avisado(a) assim que isso ocorrer!</p>";
 			
 			}
 		endif;

--- a/includes/class-wc-paghiper-transaction.php
+++ b/includes/class-wc-paghiper-transaction.php
@@ -372,7 +372,11 @@ class WC_PagHiper_Transaction {
 
 	public function create_transaction() {
 
-		if($this->has_issued_valid_transaction() || apply_filters('woo_paghiper_pending_status', $this->set_status_when_waiting, $this->order) !== $this->order_status) {
+		if($this->has_issued_valid_transaction()) {
+			return false;
+		}
+
+		if(apply_filters('woo_paghiper_pending_status', $this->gateway_settings['set_status_when_waiting'], $this->order) !== $this->order_status && !in_array($this->order_status, ['wc-pending', 'pending'])) {
 			return false;
 		}
 

--- a/includes/class-wc-paghiper-transaction.php
+++ b/includes/class-wc-paghiper-transaction.php
@@ -132,7 +132,7 @@ class WC_PagHiper_Transaction {
 					$this->invalid_reason = 'different_due_date';
 	
 					if ( $this->log ) {
-						$log_message = 'Pedido #%s: Data de vencimento do boleto não bate com a informada no pedido. Um novo boleto será gerado.';
+						$log_message = 'Pedido #%s: Data de vencimento da transação não bate com a informada no pedido. Uma nova transação será gerado.';
 						wc_paghiper_add_log( $this->log, sprintf( $log_message, $this->order_id ) );
 					}
 				}

--- a/includes/wc-paghiper-notification.php
+++ b/includes/wc-paghiper-notification.php
@@ -142,8 +142,12 @@ function paghiper_increase_order_stock( $order, $settings ) {
 
     /* Changing setting keys from Woo-Boleto-Paghiper 1.2.6.1 */
     $replenish_stock = ($settings['replenish_stock'] !== '') ? $settings['replenish_stock'] : $settings['incrementar-estoque'];
-
     $order_id = $order->get_id();
+
+    // Locks this action for misfiring when order is placed with other gateways
+    if(!in_array($order->get_payment_method(), ['paghiper', 'paghiper_billet', 'paghiper_pix'])) {
+        return;
+    }
     
     if ( 'yes' === get_option( 'woocommerce_manage_stock' ) && $replenish_stock == 'yes' && $order && 0 < count( $order->get_items() ) ) {
         if ( apply_filters( 'woocommerce_payment_complete_reduce_order_stock', $order, $order_id ) ) {

--- a/includes/wc-paghiper-notification.php
+++ b/includes/wc-paghiper-notification.php
@@ -145,7 +145,7 @@ function paghiper_increase_order_stock( $order, $settings ) {
 
     $order_id = $order->get_id();
     
-    if ( 'yes' === get_option( 'woocommerce_manage_stock' ) && $replenish_stock == true && $order && 0 < count( $order->get_items() ) ) {
+    if ( 'yes' === get_option( 'woocommerce_manage_stock' ) && ($replenish_stock === true || $replenish_stock == 'true') && $order && 0 < count( $order->get_items() ) ) {
         if ( apply_filters( 'woocommerce_payment_complete_reduce_order_stock', $order, $order_id ) ) {
             if ( function_exists( 'wc_maybe_increase_stock_levels' ) ) {
                 wc_maybe_increase_stock_levels( $order_id );

--- a/includes/wc-paghiper-notification.php
+++ b/includes/wc-paghiper-notification.php
@@ -31,7 +31,7 @@ function woocommerce_paghiper_valid_ipn_request($return, $order_no, $settings) {
                 break;
             case "processing" :
                 $order->update_status( $settings['set_status_when_waiting'], __( 'PagHiper: Pagamento em disputa. Para responder, faça login na sua conta Paghiper e procure pelo número da transação.', 'woo_paghiper' ) );
-                increase_order_stock( $order, $settings );
+                paghiper_increase_order_stock( $order, $settings );
                 break;
         }
 
@@ -67,7 +67,7 @@ function woocommerce_paghiper_valid_ipn_request($return, $order_no, $settings) {
                     $cancelled_status = (!empty($settings['set_status_when_cancelled'])) ? $settings['set_status_when_cancelled'] : 'cancelled';
                     
                     $order->update_status( $cancelled_status, __( 'PagHiper: Boleto Cancelado.', 'woo_paghiper' ) );
-                    increase_order_stock( $order, $settings );
+                    paghiper_increase_order_stock( $order, $settings );
                 break;
             case "paid" :
 
@@ -138,7 +138,7 @@ function woocommerce_paghiper_check_ipn_response() {
  *
  * @param int $order_id Order ID.
  */
-function increase_order_stock( $order, $settings ) {
+function paghiper_increase_order_stock( $order, $settings ) {
 
     /* Changing setting keys from Woo-Boleto-Paghiper 1.2.6.1 */
     $replenish_stock = ($settings['replenish_stock'] !== '') ? $settings['replenish_stock'] : $settings['incrementar-estoque'];

--- a/includes/wc-paghiper-notification.php
+++ b/includes/wc-paghiper-notification.php
@@ -145,7 +145,7 @@ function paghiper_increase_order_stock( $order, $settings ) {
 
     $order_id = $order->get_id();
     
-    if ( 'yes' === get_option( 'woocommerce_manage_stock' ) && ($replenish_stock === true || $replenish_stock == 'true') && $order && 0 < count( $order->get_items() ) ) {
+    if ( 'yes' === get_option( 'woocommerce_manage_stock' ) && $replenish_stock == 'yes' && $order && 0 < count( $order->get_items() ) ) {
         if ( apply_filters( 'woocommerce_payment_complete_reduce_order_stock', $order, $order_id ) ) {
             if ( function_exists( 'wc_maybe_increase_stock_levels' ) ) {
                 wc_maybe_increase_stock_levels( $order_id );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: henriqueccruz
 Donate link: https://www.paghiper.com/
 Tags: woocommerce, pix, boleto, paghiper, pagamento, gateway
 Requires at least: 3.5
-Tested up to: 5.6.1
+Tested up to: 5.7
 Stable tag: 2.1.4
 Requires PHP: 5.6
 License: GPLv2 or later
@@ -19,11 +19,11 @@ O plug-in anexa o boleto, mostra código de barras e linha digitável nos e-mail
 
 Fácil, prático e rápido!
 
-* **Versão mais Recente:** 2.1.4
+* **Versão mais Recente:** 2.1.5
 * **Requer WooCommerce** versão mínima 3.5
 * **Requer Wordpress** preferencialmente atualizado
 * **Requisitos:** PHP >= 5.6, cURL ativado.
-* **Compatibilidade:** Wordpress 5.6.1, Woocommerce 5.0, PHP 7.4.
+* **Compatibilidade:** Wordpress 5.7, Woocommerce 5.0, PHP 7.4.
 
 
 # Como Instalar
@@ -54,6 +54,16 @@ Para dúvidas comerciais e/ou sobre o funcionamento do serviço, visite a nossa 
 
 - Envio de e-mails de lembrete automatizados pelo Woocommerce, com comunicação da loja para maior conversão
 - Implementação de funcionalidade de boleto parcelado
+
+## 2.1.5 - 2021/04/14
+
+- Melhoria: Mais informações nos logs
+- Melhoria: Lógica de re-emissão aprimorada
+- Bugfix: Transações (PIX e Boleto) sendo geradas duas vezes na criação do pedido
+- Bugfix: Cancelamento de PIX e boleto não mudam mais o status do pedido, mesmo que o método de pagamento tenha sido mudado
+- Bugfix: E-mails de nova data de vencimento não eram enviados (dependendo da versão do Woocommerce)
+- Bugfix: Controle mais estrito do estoque
+- Bugfix: Instruções de pagamento eram mostrados várias vezes, dependendo das condições
 
 ## 2.1.4 - 2021/02/14
 

--- a/woocommerce-paghiper.php
+++ b/woocommerce-paghiper.php
@@ -443,6 +443,8 @@ class WC_Paghiper {
 		}
 
 		$payment_method = $order->get_payment_method();
+		$order_status = (strpos($order->get_status(), 'wc-') === false) ? 'wc-'.$order->get_status() : $order->get_status();
+
 		if ( in_array($payment_method, ['paghiper', 'paghiper_billet']) ) {
 
 			// Initializes plug-in options
@@ -455,7 +457,7 @@ class WC_Paghiper {
 				$this->log = wc_paghiper_initialize_log( $this->gateway_settings[ 'debug' ] );
 			}
 
-			if(apply_filters('woo_paghiper_pending_status', $this->gateway_settings['set_status_when_waiting'], $order) !== $order->status) {
+			if(apply_filters('woo_paghiper_pending_status', $this->gateway_settings['set_status_when_waiting'], $order) !== $order_status) {
 				return;
 			}
 
@@ -572,9 +574,10 @@ class WC_Paghiper {
 	 */
 	public function pending_payment_message( $order_id ) {
 		$order = new WC_Order( $order_id );
+		$order_status = (strpos($order->get_status(), 'wc-') === false) ? 'wc-'.$order->get_status() : $order->get_status();
 
 		$payment_method = $order->get_payment_method();
-		if ( in_array($payment_method, array('paghiper', 'paghiper_billet')) ) {
+		if ( in_array($payment_method, array('paghiper', 'paghiper_billet'))) {
 
 			// Initializes plug-in options
 			if(!$this->gateway_settings) {
@@ -586,7 +589,7 @@ class WC_Paghiper {
 				$this->log = wc_paghiper_initialize_log( $this->gateway_settings[ 'debug' ] );
 			}
 
-			if(apply_filters('woo_paghiper_pending_status', $this->gateway_settings['set_status_when_waiting'], $order) !== $order->status) {
+			if(apply_filters('woo_paghiper_pending_status', $this->gateway_settings['set_status_when_waiting'], $order) !== $order_status) {
 				return;
 			}
 

--- a/woocommerce-paghiper.php
+++ b/woocommerce-paghiper.php
@@ -5,13 +5,13 @@
  * Description: 			Ofereça a seus clientes pagamento por PIX e boleto bancário com a PagHiper. Fácil, prático e rapido!
  * Author: 					PagHiper Pagamentos
  * Author URI: 				https://www.paghiper.com
- * Version: 				2.1.4
- * Tested up to: 			5.6.1
+ * Version: 				2.1.5
+ * Tested up to: 			5.7
  * License: 				GPLv2 or later
  * Text Domain: 			woo-boleto-paghiper
  * Domain Path: 			/languages/
  * WC requires at least: 	3.5
- * WC tested up to: 		5.0
+ * WC tested up to: 		5.2.0
  */	
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -32,7 +32,7 @@ class WC_Paghiper {
 	 *
 	 * @var string
 	 */
-	const VERSION = '2.1.4';
+	const VERSION = '2.1.5';
 
 	/**
 	 * Instance of this class.

--- a/woocommerce-paghiper.php
+++ b/woocommerce-paghiper.php
@@ -71,7 +71,7 @@ class WC_Paghiper {
 			add_filter( 'template_include', array( $this, 'paghiper_template' ), 9999 );
 			add_action( 'woocommerce_view_order', array( $this, 'pending_payment_message' ) );
 			add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'plugin_action_links' ) );
-			add_filter( 'woocommerce_new_order', array($this, 'generate_transaction') );
+			//add_filter( 'woocommerce_new_order', array($this, 'generate_transaction') );
 			add_filter( 'woocommerce_email_attachments', array($this, 'attach_billet'), 10, 3 );
 			add_action( 'wp_enqueue_scripts', array( $this, 'load_plugin_assets' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'load_plugin_assets' ) );


### PR DESCRIPTION
* Melhoria: Mais informações nos logs
* Melhoria: Lógica de re-emissão aprimorada
* Bugfix: Transações (PIX e Boleto) sendo geradas duas vezes na criação do pedido
* Bugfix: Cancelamento de PIX e boleto não mudam mais o status do pedido, mesmo que o método de pagamento tenha sido mudado
* Bugfix: E-mails de nova data de vencimento não eram enviados (dependendo da versão do Woocommerce)
* Bugfix: Controle mais estrito do estoque
* Bugfix: Instruções de pagamento eram mostrados várias vezes, dependendo das condições