### PR TITLE
Olá equipe,

### DIFF
--- a/includes/class-wc-paghiper-base-gateway.php
+++ b/includes/class-wc-paghiper-base-gateway.php
@@ -412,7 +412,7 @@ class WC_Paghiper_Base_Gateway {
 
 		}
 
-		$payer_cpf_cnpj = preg_replace('/\D/', '', $payer_cpf_cnpj_value);
+		$payer_cpf_cnpj = preg_replace('/\D/', '', (string) $payer_cpf_cnpj_value);
 
 		$has_payer_fields = $this->has_payer_fields($payer_cpf_cnpj);
 		if(!$has_payer_fields) {


### PR DESCRIPTION
Encontrei um 'deprecated warning' no arquivo includes/class-wc-paghiper-base-gateway.php na linha 410 (ou próxima) relacionado ao uso da função preg_replace().

O erro ocorre porque a função preg_replace() não aceita mais 'null' como parâmetro $subject a partir do PHP 8.1. A variável $payer_cpf_cnpj_value pode chegar como null dependendo do fluxo.

A correção sugerida é fazer um type casting para string ou garantir que o valor não seja nulo:

Correção aplicada:
$payer_cpf_cnpj = preg_replace('/\D/', '', (string) $payer_cpf_cnpj_value);

Isso resolve o warning "preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated".